### PR TITLE
DB2i specific options and support for LIMIT/OFFSET

### DIFF
--- a/ISeriesProvider/DB2iSeriesDataProvider.cs
+++ b/ISeriesProvider/DB2iSeriesDataProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace LinqToDB.DataProvider.DB2iSeries
@@ -13,16 +14,21 @@ namespace LinqToDB.DataProvider.DB2iSeries
 
 	public class DB2iSeriesDataProvider : DynamicDataProviderBase
 	{
-		public DB2iSeriesDataProvider() : base(DB2iSeriesFactory.ProviderName, null)
+        public DB2iSeriesDataProvider() : this(DB2iSeriesSqlProviderFlags.Defaults.Clone())
+        {
+
+        }
+
+        public DB2iSeriesDataProvider(DB2iSeriesSqlProviderFlags dB2iSeriesSqlProviderFlags) : base(DB2iSeriesFactory.ProviderName, null)
 		{
-			SqlProviderFlags.AcceptsTakeAsParameter = false;
+            SqlProviderFlags.AcceptsTakeAsParameter = false;
 			SqlProviderFlags.AcceptsTakeAsParameterIfSkip = true;
 			SqlProviderFlags.IsDistinctOrderBySupported = true;
 			SqlProviderFlags.CanCombineParameters = false;
 			SqlProviderFlags.IsParameterOrderDependent = true;
 
 			SetCharField("CHAR", (r, i) => r.GetString(i).TrimEnd());
-			_sqlOptimizer = new DB2iSeriesSqlOptimizer(SqlProviderFlags);
+			_sqlOptimizer = new DB2iSeriesSqlOptimizer(SqlProviderFlags, dB2iSeriesSqlProviderFlags);
 		}
 
 		readonly DB2iSeriesSqlOptimizer _sqlOptimizer;

--- a/ISeriesProvider/DB2iSeriesSqlOptimizer.cs
+++ b/ISeriesProvider/DB2iSeriesSqlOptimizer.cs
@@ -5,10 +5,11 @@
 	using SqlQuery;
 	class DB2iSeriesSqlOptimizer : BasicSqlOptimizer
 	{
-
-		public DB2iSeriesSqlOptimizer(SqlProviderFlags sqlProviderFlags) : base(sqlProviderFlags)
+        public DB2iSeriesSqlProviderFlags DB2iSeriesSqlProviderFlags { get; private set; }
+		public DB2iSeriesSqlOptimizer(SqlProviderFlags sqlProviderFlags, DB2iSeriesSqlProviderFlags db2iSeriesSqlProviderFlags) : base(sqlProviderFlags)
 		{
-		}
+            DB2iSeriesSqlProviderFlags = db2iSeriesSqlProviderFlags;
+        }
 
 		private static void SetQueryParameter(IQueryElement element)
 		{

--- a/ISeriesProvider/DB2iSeriesSqlProviderFlags.cs
+++ b/ISeriesProvider/DB2iSeriesSqlProviderFlags.cs
@@ -1,0 +1,21 @@
+﻿using LinqToDB.SqlProvider;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LinqToDB.DataProvider.DB2iSeries
+{
+    public class DB2iSeriesSqlProviderFlags
+    {
+        public bool SupportsLimitAndOffset { get; set; }
+
+        public static DB2iSeriesSqlProviderFlags Defaults = new DB2iSeriesSqlProviderFlags();
+
+        public DB2iSeriesSqlProviderFlags Clone()
+        {
+            return this.MemberwiseClone() as DB2iSeriesSqlProviderFlags;
+        }
+    }
+}


### PR DESCRIPTION
Offset and Limit is supported from 7.1 (with some limitations) and fully from 7.3. I started adding support for it but soon realised that linq2db is missing a custom provider specific options mechanism. It does so for Sql server by adding the notion of versions but I think the i Series is so custom in configuration that I think it's better left up to the developer. So what I did was:

1. Added facility for DB2i specific provider flags:

Added  DB2iSeriesSqlProviderFlags class to host DB2i specific options (for now only SupportsLimitAndOffset). It has a singleton instance Defaults so that default options can be set at boostraping. 

Added a constructor overload at DB2iSeriesDataProvider to pass custom provider flags. If not used then a clone of defaults is created.

Added a constructor overload and private property at DB2iSeriesSqlOptimizer to pass the provider flags object (so that it is available for sql builder). 

Added a property at DB2iSeriesSqlBuilder to host the provider flags. This property is set from the sql optimizer's provider flags property if the latter is of type DB2iSeriesSqlOptimizer. In the odd case that it itsn't its cloned from defaults.

2. Implemented option for LIMIT/OFFSET support

At DB2iSeriesSqlBuilder added override for OffSetFormat, OffSetFirst and tweaked OffSetLimit and the BuildSql override to respect the DB2iSeriesSqlProviderFlags.SupportsLimitAndOffset option.


