### PR TITLE
Fix for Date and Time column predicates

### DIFF
--- a/ISeriesProvider/DB2iSeriesSqlBuilder.cs
+++ b/ISeriesProvider/DB2iSeriesSqlBuilder.cs
@@ -461,7 +461,34 @@ namespace LinqToDB.DataProvider.DB2iSeries
 
 					var ep = (SqlPredicate.ExprExpr)predicate;
 
-					if (ep.Expr1 is SqlFunction function && function.Name == "Date")
+                    if (ep.Expr1 != null && (ep.Expr1 is SqlExpression || ep.Expr1 is SqlField)
+                        && ep.Expr2 != null && ep.Expr2 is SqlParameter p2)
+                    {
+                        var p1 =
+                            (ep.Expr1 is SqlExpression tp1 && tp1.Parameters.Length == 1 && tp1.Parameters[0] is SqlField tmp1)
+                            ? 
+                            tmp1 : (ep.Expr1 is SqlField tmp2) 
+                                    ? 
+                                    tmp2 : null;
+                       
+                        if (p1 != null && p2.SystemType == typeof(DateTime))
+                        {
+                            if (p1.DataType == DataType.Date)
+                            {
+                                p2.DataType = DataType.Date;
+                                if (p2.Value != null)
+                                    p2.Value = ((DateTime)p2.Value).Date;
+                            }
+                            else if (p1.DataType == DataType.Time)
+                            {
+                                p2.DataType = DataType.Time;
+                                if (p2.Value != null)
+                                    p2.Value = new DateTime(1, 1, 1) + ((DateTime)p2.Value).TimeOfDay;
+                            }
+                        }
+                    }
+
+                    if (ep.Expr1 is SqlFunction function && function.Name == "Date")
 					{
 						if (ep.Expr2 is SqlParameter parameter)
 						{


### PR DESCRIPTION
This patch fixes the "A conversion error has occured" thrown by IBM.Data.DB2.iSeries when trying to execute a query with a predicate on a Date or Time column. In the current implementation the datetype for the parameter is set to DataType.DateTime which creates an iDb2DateTime parameter instead of iDb2Date or iDB2Time respectively.

The patch checks of the predicate is an operation between a field and a datetime value (or an expression of a single field and a datetime value - this happens on projections). If the check is true the sql field data type is checked and the value time is changed accordingly